### PR TITLE
Play nicely with batching updates

### DIFF
--- a/src/Blink.js
+++ b/src/Blink.js
@@ -18,7 +18,11 @@ var Blink = React.createClass({
 	},
 	blink () {
 		if (!this.isMounted()) return;
-		this.setState({ visible: !this.state.visible });
+		this.setState(prevState => {
+			return {
+				visible: !prevState.visible
+			};
+		});
 		setTimeout(this.blink, this.props.duration);
 	},
 	componentDidMount () {


### PR DESCRIPTION
setState calls that rely on current state should instead use a function to
determine the new state.

The reason for this is that the reconciler may batch updates, and
this.state could contain "left over" state.